### PR TITLE
Chase FreeBSD base commit r338318:

### DIFF
--- a/src/dev/drm/drm_scatter.c
+++ b/src/dev/drm/drm_scatter.c
@@ -99,7 +99,7 @@ drm_sg_cleanup(struct drm_sg_mem *entry)
 		return;
 
 	if (entry->vaddr != 0)
-		kmem_free(kernel_arena, entry->vaddr, IDX_TO_OFF(entry->pages));
+		kmem_free(entry->vaddr, IDX_TO_OFF(entry->pages));
 
 	free(entry->busaddr, DRM_MEM_SGLISTS);
 	free(entry, DRM_MEM_DRIVER);

--- a/src/dev/drm2/drm_scatter.c
+++ b/src/dev/drm2/drm_scatter.c
@@ -47,7 +47,7 @@ void drm_sg_cleanup(struct drm_sg_mem * entry)
 		return;
 
 	if (entry->vaddr != 0)
-		kmem_free(kernel_arena, entry->vaddr, IDX_TO_OFF(entry->pages));
+		kmem_free(entry->vaddr, IDX_TO_OFF(entry->pages));
 
 	free(entry->busaddr, DRM_MEM_SGLISTS);
 	free(entry, DRM_MEM_DRIVER);


### PR DESCRIPTION
Eliminate the arena parameter to kmem_free().

The FreeBSD commit was made to correct an error in the function
hypercall_memfree(), where the wrong arena was being passed to
kmem_free().

Obtained from:	https://svnweb.freebsd.org/changeset/base/338318