### PR TITLE
intel_iic: set nostop attribute on the iicbus device

### DIFF
--- a/src/dev/drm2/i915/intel_iic.c
+++ b/src/dev/drm2/i915/intel_iic.c
@@ -546,6 +546,7 @@ intel_iicbb_attach(device_t idev)
 	struct intel_iic_softc *sc;
 	struct drm_device *dev;
 	struct drm_i915_private *dev_priv;
+	device_t bdev;
 	int pin, port;
 
 	sc = device_get_softc(idev);
@@ -567,7 +568,9 @@ intel_iicbb_attach(device_t idev)
 		return (ENXIO);
 	device_quiet(sc->iic_dev);
 	bus_generic_attach(idev);
-	iicbus_set_nostop(idev, true);
+	bdev = device_find_child(sc->iic_dev, "iicbus", -1);
+	if (bdev != NULL)
+		iicbus_set_nostop(bdev, true);
 
 	return (0);
 }


### PR DESCRIPTION
This should ensure proper nostop mode in the head after my upcoming change.
Status quo should not be changed for stable branches until the corresponding MFC and then the code will become correct as well.