### PR TITLE
Use vm_page_unwire_noq() instead of vm_page_unwire(PQ_NONE).

### DIFF
--- a/src/dev/drm2/i915/i915_gem.c
+++ b/src/dev/drm2/i915/i915_gem.c
@@ -4745,7 +4745,7 @@ i915_gem_wire_page(vm_object_t object, vm_pindex_t pindex, bool *fresh)
 			rv = vm_pager_get_pages(object, &page, 1, NULL, NULL);
 			if (rv != VM_PAGER_OK) {
 				vm_page_lock(page);
-				vm_page_unwire(page, PQ_NONE);
+				vm_page_unwire_noq(page);
 				vm_page_free(page);
 				vm_page_unlock(page);
 				return (NULL);

--- a/src/dev/drm2/i915/i915_gem_gtt.c
+++ b/src/dev/drm2/i915/i915_gem_gtt.c
@@ -198,7 +198,7 @@ err_pt_alloc:
 	free(ppgtt->pt_dma_addr, DRM_I915_GEM);
 	for (i = 0; i < ppgtt->num_pd_entries; i++) {
 		if (ppgtt->pt_pages[i]) {
-			vm_page_unwire(ppgtt->pt_pages[i], PQ_NONE);
+			vm_page_unwire_noq(ppgtt->pt_pages[i]);
 			vm_page_free(ppgtt->pt_pages[i]);
 		}
 	}
@@ -228,7 +228,7 @@ void i915_gem_cleanup_aliasing_ppgtt(struct drm_device *dev)
 
 	free(ppgtt->pt_dma_addr, DRM_I915_GEM);
 	for (i = 0; i < ppgtt->num_pd_entries; i++) {
-		vm_page_unwire(ppgtt->pt_pages[i], PQ_NONE);
+		vm_page_unwire_noq(ppgtt->pt_pages[i]);
 		vm_page_free(ppgtt->pt_pages[i]);
 	}
 	free(ppgtt->pt_pages, DRM_I915_GEM);

--- a/src/dev/drm2/ttm/ttm_page_alloc.c
+++ b/src/dev/drm2/ttm/ttm_page_alloc.c
@@ -136,7 +136,7 @@ ttm_vm_page_free(vm_page_t m)
 	KASSERT((m->oflags & VPO_UNMANAGED) == 0, ("ttm got unmanaged %p", m));
 	m->flags &= ~PG_FICTITIOUS;
 	m->oflags |= VPO_UNMANAGED;
-	vm_page_unwire(m, PQ_NONE);
+	vm_page_unwire_noq(m);
 	vm_page_free(m);
 }
 


### PR DESCRIPTION
This matches src r348785 and is required for some planned KPI changes,
so get ahead of them.