### PR TITLE
Unbreak build with Clang 10 on -CURRENT

### DIFF
--- a/src/dev/drm2/radeon/evergreen.c
+++ b/src/dev/drm2/radeon/evergreen.c
@@ -551,7 +551,7 @@ bool evergreen_hpd_sense(struct radeon_device *rdev, enum radeon_hpd_id hpd)
 	case RADEON_HPD_6:
 		if (RREG32(DC_HPD6_INT_STATUS) & DC_HPDx_SENSE)
 			connected = true;
-			break;
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
See [error log](http://package18.nyi.freebsd.org/data/headamd64244251-default/2020-02-24_21h29m01s/logs/errors/drm-legacy-kmod-g20191217.log)