### PR TITLE
Add notice about this driver being obsolete

### DIFF
--- a/src/dev/drm/drm.h
+++ b/src/dev/drm/drm.h
@@ -1145,4 +1145,12 @@ typedef struct drm_mm_init_arg drm_mm_init_arg_t;
 typedef enum drm_bo_type drm_bo_type_t;
 #endif
 
+#define DRM_OBSOLETE(dev)							\
+    do {									\
+	device_printf(dev, "=======================================================\n"); \
+	device_printf(dev, "This module is deprecated.\n");			\
+	device_printf(dev, "=======================================================\n"); \
+	gone_in_dev(dev, 13, "drm legacy drivers");					\
+    } while (0)
+
 #endif

--- a/src/dev/drm/drm_drv.c
+++ b/src/dev/drm/drm_drv.c
@@ -174,7 +174,8 @@ int drm_probe(device_t kdev, drm_pci_id_list_t *idlist)
 			DRM_DEBUG("desc : %s\n", device_get_desc(kdev));
 			device_set_desc(kdev, id_entry->name);
 		}
-		return 0;
+		DRM_OBSOLETE(kdev);
+		return BUS_PROPBE_GENERIC;
 	}
 
 	return ENXIO;

--- a/src/dev/drm2/drm_os_freebsd.c
+++ b/src/dev/drm2/drm_os_freebsd.c
@@ -126,7 +126,8 @@ drm_probe_helper(device_t kdev, const drm_pci_id_list_t *idlist)
 			    device_get_nameunit(kdev), id_entry->name);
 			device_set_desc(kdev, id_entry->name);
 		}
-		return (0);
+		DRM_OBSOLETE(kdev);
+		return (-BUS_PROBE_GENERIC);
 	}
 
 	return (-ENXIO);

--- a/src/dev/drm2/drm_os_freebsd.h
+++ b/src/dev/drm2/drm_os_freebsd.h
@@ -154,6 +154,16 @@ typedef void			irqreturn_t;
 	*(volatile u_int64_t *)(((vm_offset_t)(map)->handle) +		\
 	    (vm_offset_t)(offset)) = htole64(val)
 
+#define DRM_PORT "graphics/drm-kmod"
+
+#define DRM_OBSOLETE(dev)							\
+    do {									\
+	device_printf(dev, "=======================================================\n"); \
+	device_printf(dev, "This module is deprecated.  Install the " DRM_PORT " pkg\n"); \
+	device_printf(dev, "=======================================================\n"); \
+	gone_in_dev(dev, 13, "drm legacy drivers");				\
+    } while (0)
+
 /* DRM_READMEMORYBARRIER() prevents reordering of reads.
  * DRM_WRITEMEMORYBARRIER() prevents reordering of writes.
  * DRM_MEMORYBARRIER() prevents reordering of reads and writes.


### PR DESCRIPTION
Add a notice, wich will be printed when the driver loads, about this
driver being obsolete and deprecated.  For now, say that the driver will
be gone in 13, it will probably be removed from 12 as well, but start
with 13.
Discussed at the graphics team meeting

Signed-off-by: Niclas Zeising <zeising@daemonic.se>